### PR TITLE
feat: blind secrets in configuration module

### DIFF
--- a/Classes/Hook/BlindedConfigurationOptionsHook.php
+++ b/Classes/Hook/BlindedConfigurationOptionsHook.php
@@ -1,0 +1,34 @@
+<?php
+// TODO remove if support for TYPO3 11 dropped
+
+namespace OliverKroener\OkExchange365\Hook;
+class BlindedConfigurationOptionsHook
+{
+
+    private static $blindedMailSettings = [
+        'transport_exchange365_clientId',
+        'transport_exchange365_tenantId',
+        'transport_exchange365_clientSecret',
+    ];
+
+    /**
+     * Blind exchange 365 credentials in ConfigurationOptions
+     *
+     * @param array $blindedConfigurationOptions
+     * @return array
+     */
+    public function modifyBlindedConfigurationOptions(array $blindedConfigurationOptions): array
+    {
+        foreach (self::$blindedMailSettings as $key) {
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key])) {
+                $blindedConfigurationOptions['TYPO3_CONF_VARS']['MAIL'][$key] =
+                    mb_substr($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key], 0, 2) .
+                    '******' .
+                    mb_substr($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key], -2, 2);
+            }
+        }
+
+        return $blindedConfigurationOptions;
+    }
+
+}

--- a/Classes/Lowlevel/EventListener/ModifyBlindedConfigurationOptionsEventListener.php
+++ b/Classes/Lowlevel/EventListener/ModifyBlindedConfigurationOptionsEventListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OliverKroener\OkExchange365\Lowlevel\EventListener;
+
+use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
+
+final class ModifyBlindedConfigurationOptionsEventListener
+{
+    public function __invoke(ModifyBlindedConfigurationOptionsEvent $event): void
+    {
+        $options = $event->getBlindedConfigurationOptions();
+
+        if ($event->getProviderIdentifier() === 'confVars') {
+            $options = $this->modifyBlindedConfigurationOptions($options);
+        }
+
+        $event->setBlindedConfigurationOptions($options);
+    }
+
+    private static $blindedMailSettings = [
+        'transport_exchange365_clientId',
+        'transport_exchange365_tenantId',
+        'transport_exchange365_clientSecret',
+    ];
+
+    /**
+     * Blind exchange 365 credentials in ConfigurationOptions
+     *
+     * @param array $blindedConfigurationOptions
+     * @return array
+     */
+    public function modifyBlindedConfigurationOptions(array $blindedConfigurationOptions): array
+    {
+        foreach (self::$blindedMailSettings as $key) {
+            if (!empty($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key])) {
+                $blindedConfigurationOptions['TYPO3_CONF_VARS']['MAIL'][$key] =
+                    mb_substr($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key], 0, 2) .
+                    '******' .
+                    mb_substr($GLOBALS['TYPO3_CONF_VARS']['MAIL'][$key], -2, 2);
+            }
+        }
+
+        return $blindedConfigurationOptions;
+    }
+
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -9,5 +9,7 @@ services:
     resource: '../Classes/*'
     exclude: '../Classes/Mail/Transport/Exchange365Transport.php'
 
-
-
+  OliverKroener\OkExchange365\Lowlevel\EventListener\ModifyBlindedConfigurationOptionsEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'ok-exchange365-mailer/blind-configuration-options'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,3 +1,10 @@
 <?php
 
 defined('TYPO3') || die();
+
+// TODO remove if support for TYPO3 11 dropped
+if ((\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class))->getMajorVersion() < 12 ) {
+    // Add Hook for blindedConfigurationValues
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][\TYPO3\CMS\Lowlevel\Controller\ConfigurationController::class]['modifyBlindedConfigurationOptions'][] =
+        OliverKroener\OkExchange365\Hook\BlindedConfigurationOptionsHook::class;
+}


### PR DESCRIPTION
Hi @oliverkroener ,

another thing I would recommend is blinding the secrets in the configuration module.

Should work with TYPO3 11 and 12. v13 untested